### PR TITLE
Updates for compatibility with bbotk >= 0.5.2

### DIFF
--- a/R/OptimizerMies.R
+++ b/R/OptimizerMies.R
@@ -286,6 +286,7 @@ OptimizerMies = R6Class("OptimizerMies", inherit = Optimizer,
       properties_determinants = discard(list(parent_selector, survival_selector, elite_selector), is.null)
 
       super$initialize(
+        id = "mies",
         param_set = self$param_set,  # essentially a nop, since at this point we already set private$.param_set, but we can't give NULL here.
         param_classes = Reduce(intersect, map(param_class_determinants, "param_classes")),
         properties = c("dependencies", Reduce(intersect, map(properties_determinants, "supported"))),

--- a/R/TerminatorBudget.R
+++ b/R/TerminatorBudget.R
@@ -45,8 +45,7 @@ TerminatorBudget = R6Class("TerminatorBudget", inherit = Terminator,
         "must be a function with one argument, which when called with NULL must return a finite numeric value."
       }))
       param_set$values = list(budget = Inf, aggregate = sum)
-      super$initialize(param_set = param_set, properties = c("single-crit", "multi-crit"))
-      self$unit = "percent"
+      super$initialize(id = "budget", param_set = param_set, properties = c("single-crit", "multi-crit"), unit = "percent")
     },
 
     #' @description

--- a/R/TerminatorGenerations.R
+++ b/R/TerminatorGenerations.R
@@ -43,8 +43,7 @@ TerminatorGenerations = R6Class("TerminatorGenerations", inherit = Terminator,
     initialize = function() {
       param_set = ps(generations = p_int(0, special_vals = list(Inf), tags = "required"))
       param_set$values$generations = Inf
-      super$initialize(param_set = param_set, properties = c("single-crit", "multi-crit"))
-      self$unit = "generations"
+      super$initialize(id = "gens", param_set = param_set, properties = c("single-crit", "multi-crit"), unit = "generations")
     },
 
     #' @description


### PR DESCRIPTION
`bbotk (>= 0.5.2)` is not compatible with the miesmuschel multiobjective_hb branch because bbotk has an `id`field now for terminators and optimizers. Without an update, I would run into an error for: 
```
> library("bbotk")
> library("miesmuschel")
> t = trm("gens")
Error in assert_string(id, min.chars = 1L) : 
  argument "id" is missing, with no default
```
I added an id field to terminators and optimizers, and updated how unit is initialized. 